### PR TITLE
fix: replace h1 with p in banner to fix duplicate heading SEO issue

### DIFF
--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -17,7 +17,7 @@ const Banner: FunctionalComponent<Props> = ({ header }) => {
       <div className="ct-banner-intro">
         <div className="ct-banner-header">
           {keyExists('subTitle') && <p>{getValue('subTitle')}</p>}
-          {keyExists('title') && <h1>{getValue('title')}</h1>}
+          {keyExists('title') && <p className="ct-banner-title">{getValue('title')}</p>}
         </div>
         <div className="ct-banner-logo">
           <svg

--- a/src/components/banner/style.css
+++ b/src/components/banner/style.css
@@ -7,13 +7,12 @@
   max-width: 85%;
 }
 
-.ct-banner p,
-.ct-banner h1 {
+.ct-banner p {
   margin-top: 0;
   margin-bottom: var(--ct-text-margin);
 }
 
-.ct-banner h1 {
+.ct-banner .ct-banner-title {
   font-size: var(--ct-heading-font-size);
   font-weight: 700;
   color: var(--ct-title);

--- a/src/tests/components/banner/banner.test.tsx
+++ b/src/tests/components/banner/banner.test.tsx
@@ -15,8 +15,12 @@ describe('Banner', () => {
 
   it('can render with a header', () => {
     const wrapper = shallow(<Banner header={mockConfig.header} />);
-    expect(wrapper.find('.ct-banner-header').find('p').text()).toEqual(mockConfig.header.subTitle);
-    expect(wrapper.find('.ct-banner-header').find('h1').text()).toEqual(mockConfig.header.title);
+    expect(wrapper.find('.ct-banner-header').find('p:not(.ct-banner-title)').text()).toEqual(
+      mockConfig.header.subTitle,
+    );
+    expect(wrapper.find('.ct-banner-header').find('.ct-banner-title').text()).toEqual(
+      mockConfig.header.title,
+    );
     expect(wrapper.find('.ct-banner-explanation').text()).toEqual(mockConfig.header.description);
   });
 });


### PR DESCRIPTION
## Summary

- Replaces `<h1>` with `<p class="ct-banner-title">` in the cookie banner component
- Fixes a critical SEO issue where Googlebot (which renders open Shadow DOM) indexed the banner title as an `<h1>` on every page of the site, creating duplicate/conflicting headings
- Updates CSS to scope heading styles to `.ct-banner-title` class instead of the `h1` element
- Updates test selector to use `.ct-banner-title` and `p:not(.ct-banner-title)` to disambiguate the two paragraph elements

## Why

Googlebot renders JavaScript including open Shadow DOM. The cookie banner rendered `<h1>cookie though?</h1>` inside its shadow root, which Google saw on every page alongside the real page `<h1>`. This caused multiple H1s per page and "cookie though?" potentially ranking as the primary heading for all pages.

## Test plan

- [ ] Run `npm test` — banner tests pass
- [ ] Deploy and verify with Google Search Console that duplicate H1 warnings clear
- [ ] Visual regression check: banner title should look identical (styles preserved via `.ct-banner-title` class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)